### PR TITLE
Support for UserDefinedValue can be fetched from configured json DataSource

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     compile "org.parboiled:parboiled-java:$parboiledJavaVersion"
     compile "org.yaml:snakeyaml:$snakeyamlVersion"
     compile "org.apache.commons:commons-csv:$commonsCsvVersion"
+    compile "com.googlecode.json-simple:json-simple:$gsonVersion"
+    compile "com.jayway.jsonpath:json-path:$jsonPathVersion"
 
     testCompile "junit:junit:$junitVersion"
     testCompile "org.spockframework:spock-core:$spockCoreVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,5 @@ junitVersion=4.12
 spockCoreVersion=1.0-groovy-2.4
 cglibNodepVersion=3.2.0
 groovyAllVersion=2.4.3
+gsonVersion=1.1
+jsonPathVersion=2.3.0

--- a/src/main/java/io/smartcat/ranger/core/UserDefinedValue.java
+++ b/src/main/java/io/smartcat/ranger/core/UserDefinedValue.java
@@ -1,0 +1,143 @@
+package io.smartcat.ranger.core;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.jayway.jsonpath.JsonPath;
+
+/**
+ * @author hkilari
+ * 
+ *         UserDefined Value Implementation to allow Berserker User define a Custom Value in
+ *         berserker ranger configuration. The Custom Value will be retrieved from the data source
+ *         configured by User based on his query config
+ *
+ */
+public class UserDefinedValue extends Value<String> {
+
+    private Value<String> jsonName;
+    private Value<String> filter;
+    private Value<String> regExpression;
+    private List<String> finalContent;
+    private long contentlastUpdationTime;
+    private Value<String> refreshInterval;
+    private Value<String> defaultRefreshInterval = new Value<String>() {
+    };
+
+    public UserDefinedValue(Value<String> regExpression, Value<String> refreshInterval, Value<String> filter,
+            Value<String> jsonName) {
+        defaultRefreshInterval.val = "600";
+        if (jsonName == null) {
+            throw new IllegalArgumentException("datasource cannot be null.");
+        }
+        this.jsonName = jsonName;
+        this.filter = filter;
+        this.regExpression = regExpression;
+        this.refreshInterval = refreshInterval == null ? defaultRefreshInterval : refreshInterval;
+        this.finalContent = new ArrayList<>();
+    } 
+
+    @Override
+    public void reset() {
+        jsonName.reset();
+        filter.reset();
+        regExpression.reset();
+        refreshInterval.reset();
+        super.reset();
+
+    }
+
+    @Override
+    protected void eval() {
+        if (isContentExpired()) {
+            getDataFromJson();
+        }
+        val = getRandomValue();
+    }
+
+    private boolean isContentExpired() {
+        //Checks if the finalContent to be  refreshed based on used defined refreshInterval.
+        if (System.currentTimeMillis() - contentlastUpdationTime > Long.parseLong(refreshInterval.val) * 1000) {
+            return true;
+        }
+        return false;
+    }
+
+    private String getRandomValue() {
+        if (finalContent != null && !finalContent.isEmpty())
+            return extractField(finalContent.get(new Random().nextInt(finalContent.size())).toString(),
+                    regExpression.get());
+        else
+            return "";
+    }
+
+    private void getDataFromJson() {
+        try {
+            //check If Source is a http service
+            if (jsonName.get().contains("http")) {
+                getDataFromHttpRequest();
+            } else {
+                //Source treated as a local json file
+                InputStream in =
+                        Thread.currentThread().getContextClassLoader().getResourceAsStream(jsonName.get() + ".json");
+                if (in == null) {
+                    in = new FileInputStream(jsonName.get() + ".json");
+                }
+                if (in != null) {
+                    finalContent = JsonPath.read(in, filter.get());
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Retrieves data from a http servcie endpoint
+     */
+    private void getDataFromHttpRequest() {
+        try {
+            InputStream in;
+            URL obj = new URL(jsonName.val);
+            HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+            con.setRequestMethod("GET");
+            con.setRequestProperty("accept", "application/json");
+            int responseCode = con.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_OK) { // success
+                in = con.getInputStream();
+                finalContent = JsonPath.read(in, filter.get());
+                in.close();
+                contentlastUpdationTime = System.currentTimeMillis();
+            } else {
+                System.out.println("GET request not worked");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * @param latestCommandOutput
+     * @param regExpression
+     * @return
+     */
+    private String extractField(String inputString, String regExpression) {
+        if (regExpression != null && !"".equals(regExpression.trim())) {
+            Pattern p = Pattern.compile(regExpression);
+            Matcher m = p.matcher(inputString);
+            if (m.find()) {
+                if (m.groupCount() > 0)
+                    return m.group(1);
+            }
+            return null;
+        }
+        return inputString;
+    }
+}

--- a/src/main/java/io/smartcat/ranger/parser/ValueExpressionParser.java
+++ b/src/main/java/io/smartcat/ranger/parser/ValueExpressionParser.java
@@ -33,6 +33,7 @@ import io.smartcat.ranger.core.RangeValueLong;
 import io.smartcat.ranger.core.StringTransformer;
 import io.smartcat.ranger.core.TimeFormatTransformer;
 import io.smartcat.ranger.core.UUIDValue;
+import io.smartcat.ranger.core.UserDefinedValue;
 import io.smartcat.ranger.core.Value;
 import io.smartcat.ranger.core.ValueProxy;
 import io.smartcat.ranger.core.WeightedValue;
@@ -750,7 +751,18 @@ public class ValueExpressionParser extends BaseParser<Object> {
         return Sequence(function("randomContentString", Sequence(value(), Optional(comma(), bracketList(charRange())))),
                 push(createRandomContentStringValue()));
     }
-
+    
+    /**
+     * UserDefined Content Value definition
+     * 
+     * @return UserDefined Content Value definition Rule
+     */
+    public Rule userDefinedValue() {
+            return Sequence(
+                            function("userDefinedValue", Sequence(value(), comma(), value(), comma(), value(), comma(), value())),
+                            push(createUserDefinedValue()));
+    }
+    
     /**
      * Now definition.
      *
@@ -852,7 +864,7 @@ public class ValueExpressionParser extends BaseParser<Object> {
         return FirstOf(discreteValue(), rangeValue(), uuidValue(), circularValue(), circularRangeValue(), listValue(),
                 emptyListValue(), emptyMapValue(), randomLengthListValue(), weightedValue(), exactWeightedValue(),
                 randomContentStringValue(), now(), nowDate(), nowLocalDate(), nowLocalDateTime(), additionValue(),
-                subtractionValue(), multiplicationValue(), divisionValue(), csvReaderValue());
+                subtractionValue(), multiplicationValue(), divisionValue(), csvReaderValue(),userDefinedValue());
     }
 
     /**
@@ -1168,7 +1180,17 @@ public class ValueExpressionParser extends BaseParser<Object> {
         }
         return new CsvReaderValue(parserSettings);
     }
-
+    
+    /**
+     * Creates a UserDefinedValue fetched from the configured Data Source.
+     * @return UserDefinedValue
+     */
+    @SuppressWarnings("unchecked")
+    protected UserDefinedValue createUserDefinedValue() {
+            return new UserDefinedValue((Value<String>) pop(), (Value<String>) pop(), (Value<String>) pop(),
+                            (Value<String>) pop());
+    }
+    
     /**
      * Trims off ' and " characters from beginning and end of the string.
      *


### PR DESCRIPTION
Created support for UsedDefinedValue to be fetched from a Json or http endpoint along with option to apply filter on the Datasource. This requirement is needed for me, when I tried creating berserker configurations in the form of a workflow for a Rest service having dependent rest Endpoints. And I believe that this is a requirement that most berserker users like.

Method Usage:
userDefinedValue("DataSourceName","JsonPathQuery","refreshIntervalInSeconds","regExpressionToFetchExpectedStringFromFetchedField")

DataSourceName: Can be a name of JSON file available in classpath/ A Rest endpoint that return a JSON response 

JsonPathQuery: JSON path query to extract a Filed from specified Data Source. For semantics, please refer to https://github.com/json-path/JsonPath

refreshIntervalInSeconds: To refresh the data at configured intervals if the source support dynamic data retrieval.

regExpressionToFetchExpectedStringFromFetchedField: To support the case where the requirement is not complete field and only specific part.

example definitions:
Sample JSON: 
{
  "firstName": "John",
  "lastName" : "doe",
  "age"      : 26,
  "address"  : {
    "streetAddress": "naist street",
    "city"         : "Nara",
    "postalCode"   : "630-0192"
  },
  "phoneNumbers": [
    {
      "type"  : "iPhone",
      "number": "0123-4567-8888"
    },
    {
      "type"  : "home",
      "number": "0123-4567-8910"
    }
  ]
}

userDefinedValue("resources","$.phoneNumbers[*].type","100"," ")
userDefinedValue("http:/url/resources","$.phoneNumbers[*].type","100"," ")

above Value Definition will evaluate to Values
  "iPhone",
  "home"
